### PR TITLE
enhanced .gitignore by the mvn target dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 
 ## Directory-based project format:
 .idea/
+
+target/
+
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:


### PR DESCRIPTION
I think it is a good idea to add the target directory of maven to .gitignore